### PR TITLE
fix: use EmailListValidator for invite form

### DIFF
--- a/groups/forms.py
+++ b/groups/forms.py
@@ -295,7 +295,7 @@ class EmailListValidator:
 
 class GroupInviteForm(forms.Form):
     emails = CommaSeparatedCharField(
-        validators=[EmailValidator()],
+        validators=[EmailListValidator()],
         widget=forms.Textarea,
         help_text="Enter as a comma-separated list.",
     )


### PR DESCRIPTION
## Summary
- `GroupInviteForm` used `EmailValidator()` directly on `CommaSeparatedCharField`, which validates the parsed list object as a single email string — always failing with "Enter a valid email address."
- `EmailListValidator` was already defined but never attached. It correctly iterates individual emails and enforces a 10-email limit.
- Replace `EmailValidator()` with `EmailListValidator()` on the form field.